### PR TITLE
many bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Converts Netwitness log parser configuration to Logstash configuration
 
-**Disclamer: Vincent Maury or Elastic cannot be held responsible for the use of this script! Use it at your own risk**
+**Disclamer: RSA2ELK is being published as an independent project (by Vincent Maury) and is in no way associated with, endorsed, or supported by Elastic. RSA2ELK is hereby released to the public as unsupported, open source software. Vincent Maury or Elastic cannot be held responsible for the use of this script! Use it at your own risk**
+
 
 ## Introduction (the why)
 
@@ -36,11 +37,6 @@ The script has several options:
 * `-i` or `--input-file FILE` to enter the absolute patch to the RSA XML configuration file. Alternative is url. See the note below for custom XML file.
 * `-u` or `--url URL` to enter the URL to the RSA XML configuration file. if no file or url is provided, this program will run on a [sample XML file](https://raw.githubusercontent.com/netwitness/nw-logparsers/master/devices/zscalernss/zscalernssmsg.xml) located in the RSA repo.
 * `-o` or `--output-file FILE` to enter the absolute path to the Logstash .conf file (default: `logstash-[device].conf`).
-* `-c` or `--check-config` runs on check of the generated configuration with `logstash -f` (default: false).
-* `-l` or `--logstash-path` to enter the absolute path to logstash bin executable (default is my local path!).
-* `-n` or `--no-grok-anchors` removes the begining (^) and end ($) anchors in grok (default: false, ie default is to have them).
-* `-a` or `--add-stop-anchors` adds hard stop anchors in grok to ignore in-between chars, see explanation below. Should be set as a serie of plain characters, only escaping " and \\. Example: `\"()[]` (default: "").
-* `-m` or `--single-space-match` to only match 1 space in the log if there is 1 space in the RSA parser (default: false, ie match 1-N spaces aka `[\s]+`).
 * `-p` or `--parse-url` adds a pre-defined filter block (see [filter-url.conf](filter-url.conf)) to parse URLs into domain, query, etc (default: false).
 * `-q` or `--parse-ua` adds a pre-defined filter block (see [filter-ua.conf](filter-ua.conf)) to parse User Agents (default: false).
 * `-e` or `--enrich-geo` adds a filter block (see [filter-geoip.conf](filter-geoip.conf)) to enrich public IPs with geoip information (default: false).
@@ -48,6 +44,11 @@ The script has several options:
 * `-r` or `--remove-parsed-fields` removes the event.original and message fields if correctly parsed (default: false).
 * `-s` or `--rename` renames default rsa fields to ECS fields (default: false).
 * `-t` or `--trim-fields` trims (strips left and right spaces) from all string fields (default: false).
+* `-n` or `--no-grok-anchors` removes the begining (^) and end ($) anchors in grok (default: false, ie default is to have them).
+* `-a` or `--add-stop-anchors` adds hard stop anchors in grok to ignore in-between chars, see explanation below. Should be set as a serie of plain characters, only escaping " and \\. Example: `\"()[]` (default: "").
+* `-m` or `--single-space-match` to only match 1 space in the log if there is 1 space in the RSA parser (default: false, ie match 1-N spaces aka `[\s]+`).
+* `-c` or `--check-config` runs on check of the generated configuration with `logstash -t` (default: false).
+* `-l` or `--logstash-path` to enter the absolute path to logstash bin executable (default is my local path!).
 * `-d` or `--debug` to enable debug mode, more verbose (default: false).
 
 ### Input

--- a/config.py
+++ b/config.py
@@ -54,8 +54,8 @@ ecat = {}
 allFields = set() 
 anchorFldId = 1
 withDissect = False
+parsingError = ""
 messageId = ""
-dateFields = ""
 dateFieldMutation = ""
 dateMatching = ""
 
@@ -79,11 +79,6 @@ def init():
 	parser.add_argument('-i', '--input-file', action='store', default='', help='Absolute path to RSA XML file (automatically uses the related custom XML file as well)')
 	parser.add_argument('-u', '--url', action='store', default='', help='url of RSA XML file')
 	parser.add_argument('-o', '--output-file', action='store', default='', help='Absolute path to Logstash .conf file (default: logstash-[device].conf)')
-	parser.add_argument('-c', '--check-config', action='store_true', default=False, help='Check the generated configuration with `logstash -f` (default: false)')
-	parser.add_argument('-l', '--logstash-path', action='store', default='', help='Absolute path to logstash')
-	parser.add_argument('-n', '--no-grok-anchors', action='store_true', default=False, help='Removing the begining (^) and end ($) anchors in grok (default is to have them)')
-	parser.add_argument('-a', '--add-stop-anchors', action='store', default='', help='Add hard stop anchors in grok (as a serie of plain characters, only escaping " and \\) to ignore in-between chars, for example \\"()[] (default: "")')
-	parser.add_argument('-m', '--single-space-match', action='store_true', default=False, help='Only match 1 space if there is 1 space in the RSA parser (default: false, ie match 1-N spaces aka [\\s]+)')
 	parser.add_argument('-p', '--parse-url', action='store_true', default=False, help='Add a filter block to parse URLs into domain, query, etc (default: false)')
 	parser.add_argument('-q', '--parse-ua', action='store_true', default=False, help='Add a filter block to parse User Agents (default: false)')
 	parser.add_argument('-e', '--enrich-geo', action='store_true', default=False, help='Add a filter block to add geoip lookups on IPs (default: false)')
@@ -91,6 +86,11 @@ def init():
 	parser.add_argument('-r', '--remove-parsed-fields', action='store_true', default=False, help='Remove the event.original and message fields if correctly parsed (default: false)')
 	parser.add_argument('-s', '--rename', action='store_true', default=False, help='Renames RSA fields to ECS (default: false)')
 	parser.add_argument('-t', '--trim-fields', action='store_true', default=False, help='Trim (strip left and right spaces) from all string fields (default: false)')
+	parser.add_argument('-n', '--no-grok-anchors', action='store_true', default=False, help='Removing the begining (^) and end ($) anchors in grok (default is to have them)')
+	parser.add_argument('-a', '--add-stop-anchors', action='store', default='', help='Add hard stop anchors in grok (as a serie of plain characters, only escaping " and \\) to ignore in-between chars, for example \\"()[] (default: "")')
+	parser.add_argument('-m', '--single-space-match', action='store_true', default=False, help='Only match 1 space if there is 1 space in the RSA parser (default: false, ie match 1-N spaces aka [\\s]+)')
+	parser.add_argument('-c', '--check-config', action='store_true', default=False, help='Check the generated configuration with `logstash -f` (default: false)')
+	parser.add_argument('-l', '--logstash-path', action='store', default='', help='Absolute path to logstash')
 	parser.add_argument('-d', '--debug', action='store_true', default=False, help='Debug mode, more verbose (default: false)')
 	results = parser.parse_args()
 	# capture inputs

--- a/filter-url.conf
+++ b/filter-url.conf
@@ -7,14 +7,14 @@ filter {
 		}
 		grok {
 			match => {
-		  "url.original" => [
-				# match https://user:pwd@stuff.domain.co.uk:8080/some/path?p1=v1&p2=v2#anchor
-				"%{URIPROTO:url.scheme}://(?:%{USER:url.username}:(?<url.password>[^@]*)@)?(?:%{IPORHOST:url.address}(?::%{POSINT:url.port}))?(?:%{URIPATH:url.path}(?:%{URIPARAM:url.query}))?",
-				# match stuff.domain.com:8080/some/path?p1=v1&p2=v2#anchor
-				"%{IPORHOST:url.address}(?::%{POSINT:url.port})(?:%{URIPATH:url.path}(?:%{URIPARAM:url.query}))?",
-				# match /some/path?p1=v1&p2=v2#anchor
-				"%{URIPATH:url.path}(?:%{URIPARAM:url.query})"
-		  ]
+				"url.original" => [
+					# match https://user:pwd@stuff.domain.co.uk:8080/some/path?p1=v1&p2=v2#anchor
+					"%{URIPROTO:url.scheme}://(?:%{USER:url.username}:(?<url.password>[^@]*)@)?(?:%{IPORHOST:url.address}(?::%{POSINT:url.port})?)?(?:%{URIPATH:url.path}(?:%{URIPARAM:url.query})?)?",
+					# match stuff.domain.com:8080/some/path?p1=v1&p2=v2#anchor
+					"%{IPORHOST:url.address}(?::%{POSINT:url.port})?(?:%{URIPATH:url.path}(?:%{URIPARAM:url.query})?)?",
+					# match /some/path?p1=v1&p2=v2#anchor
+					"%{URIPATH:url.path}(?:%{URIPARAM:url.query})?"
+				]
 			}
 			add_tag => [ "urlparsed" ]
 		}
@@ -28,9 +28,9 @@ filter {
 			# parse the query to extract fragment
 			grok {
 				match => {
-					"url.query" => "^\?(?<url.query>[A-Za-z0-9$.+!*'|(){},~@%&/=:;_?\-\[\]<>]*)(?:#(?:%{WORD:url.fragment}))?"
+					"url.query" => "^\?(?<url.query>[A-Za-z0-9$.+!*'|(){},~@%&/=:;_?\-\[\]<>]*)(?:#(?:%{WORD:url.fragment})?)?"
 				}
-		  overwrite => [ "url.query" ]
+				overwrite => [ "url.query" ]
 			}
 			# chunk the query string in pieces (resource intensive and can produce huge mappings. see flattened json field type instead, cf https://discuss.elastic.co/t/parsing-url-with-logstash-using-ecs-fields-nested/209953/4)
 	#		kv {

--- a/funcs.py
+++ b/funcs.py
@@ -26,73 +26,99 @@ def removeDots(s):
     else:
         return s
 
-# extract date fields from functions string, example is @event_time:*EVNTTIME($MSG,'%B %F %N:%U:%O %W',datetime)
-def extractDateFields(s):
-    eventtime = s.find("EVNTTIME")
-    if eventtime != -1:
-        # go to the third parameter of the EVENTTIME func to extract the field
-        a = s.find(",",eventtime)
-        if a != -1:
-            b = s.find(",",a+1)
-            if b>a:
-                c = s.find(")",b+1)
-                return s[b+1:c]
-    return ""
+def convertDate(s):
+    dateList = set()
+    pattern = re.compile(",'([^']+)'")
+    for dStr in pattern.finditer(s):
+        c = dStr.group(1)
+        # replace the specific chars by their logstash date filter equivalent
+        c = c.replace("%C", "M/d/yy H:m:s")
+        c = c.replace("%R", "MMMM")
+        c = c.replace("%B", "MMM")
+        c = c.replace("%M", "MM")
+        c = c.replace("%G", "M")
+        c = c.replace("%D", "dd")
+        c = c.replace("%F", "d")
+        c = c.replace("%H", "HH")
+        c = c.replace("%I", "HH")
+        c = c.replace("%N", "H")
+        c = c.replace("%T", "mm")
+        c = c.replace("%U", "m")
+        c = c.replace("%J", "D")
+        c = c.replace("%P", "a")
+        c = c.replace("%S", "ss")
+        c = c.replace("%O", "s")
+        c = c.replace("%Y", "yy")
+        c = c.replace("%W", "yyyy")
+        c = c.replace("%Z", "H:m:s")
+        c = c.replace("%A", "D")
+        c = c.replace("%Q", "a")    # AM/PM
+        c = c.replace("%K", "")    # undocumented... seen in cef.xml
+        c = c.replace("%L", "")    # undocumented... seen in cef.xml
+        c = c.replace("%E", "")    # undocumented... seen in v20_trendmicromsg.xml
+        c = c.replace("%X", "UNIX")
+        if '%' in c: print("Missing a condition in date conversion: " + c)
+        dateList.add(c)
+    return "\"" + "\", \"".join(dateList) + "\""
 
 # extract date parsing format from functions string and convert to logstash format
 # change date, ref is https://community.rsa.com/docs/DOC-85016 pages 37-38 vs https://www.elastic.co/guide/en/logstash/current/plugins-filters-date.html#plugins-filters-date-match
-# for example "10/Oct/2000:13:55:36 -0700" is parsed in RSA with "%D/%B/%W:%N:%U:%O" and "dd/MMM/yyyy:HH:mm:ss" in logstash
-def convertDate(s):
-    c = ""
-    eventtime = s.find("EVNTTIME")
-    if eventtime != -1:
-        # extract the date format between the ''
-        a = s.find("'",eventtime)
-        if a != -1:
-            b = s.find("'",a+1)
-            if b>a:
-                sub = s[a+1:b]
-                # replace static chars
-                regex = re.compile("([a-zA-Z]+)")		# just matching a letter
-                for i in range(0,len(sub)):
-                    if regex.match(sub[i]):
-                        # if first character is a letter, escape it
-                        if i == 0:
-                            c = c + "'" + sub[i] + "'"
-                        else:
-                            # if char not preceded by a %, escape it
-                            if sub[i-1:i] != '%':
-                                c = c + "'" + sub[i] + "'"
-                            else:
-                                # otherwise add it
-                                c = c + sub[i]
-                    else:
-                        # otherwise add it
-                        c = c + sub[i]
-                # replace the specific chars by their logstash date filter equivalent
-                c = c.replace("%C", "M/d/yy H:m:s")
-                c = c.replace("%R", "MMMM")
-                c = c.replace("%B", "MMM")
-                c = c.replace("%M", "MM")
-                c = c.replace("%G", "M")
-                c = c.replace("%D", "dd")
-                c = c.replace("%F", "d")
-                c = c.replace("%H", "HH")
-                c = c.replace("%I", "HH")
-                c = c.replace("%N", "H")
-                c = c.replace("%T", "mm")
-                c = c.replace("%U", "m")
-                c = c.replace("%J", "D")
-                c = c.replace("%P", "a")
-                c = c.replace("%S", "ss")
-                c = c.replace("%O", "s")
-                c = c.replace("%Y", "yy")
-                c = c.replace("%W", "yyyy")
-                c = c.replace("%Z", "H:m:s")
-                c = c.replace("%A", "D")
-                c = c.replace("%X", "UNIX")
-                if '%' in c and config.DEBUG: print("Missing a condition in date conversion")
-    return c
+# for example "10/Oct/2000:13:55:36" is parsed in RSA with "%D/%B/%W:%N:%U:%O" and "dd/MMM/yyyy:HH:mm:ss" in logstash
+# def convertDate(s):
+#     c = ""
+#     eventtime = s.find("EVNTTIME")
+#     if eventtime != -1:
+#         # extract the date format between the ''
+#         a = s.find("'",eventtime)
+#         if a != -1:
+#             b = s.find("'",a+1)
+#             if b>a:
+#                 sub = s[a+1:b]
+#                 # replace static chars
+#                 regex = re.compile("([a-zA-Z]+)")		# just matching a letter
+#                 for i in range(0,len(sub)):
+#                     if regex.match(sub[i]):
+#                         # if first character is a letter, escape it
+#                         if i == 0:
+#                             c = c + "'" + sub[i] + "'"
+#                         else:
+#                             # if char not preceded by a %, escape it
+#                             if sub[i-1:i] != '%':
+#                                 c = c + "'" + sub[i] + "'"
+#                             else:
+#                                 # otherwise add it
+#                                 c = c + sub[i]
+#                     else:
+#                         # otherwise add it
+#                         c = c + sub[i]
+#                 # replace the specific chars by their logstash date filter equivalent
+#                 c = c.replace("%C", "M/d/yy H:m:s")
+#                 c = c.replace("%R", "MMMM")
+#                 c = c.replace("%B", "MMM")
+#                 c = c.replace("%M", "MM")
+#                 c = c.replace("%G", "M")
+#                 c = c.replace("%D", "dd")
+#                 c = c.replace("%F", "d")
+#                 c = c.replace("%H", "HH")
+#                 c = c.replace("%I", "HH")
+#                 c = c.replace("%N", "H")
+#                 c = c.replace("%T", "mm")
+#                 c = c.replace("%U", "m")
+#                 c = c.replace("%J", "D")
+#                 c = c.replace("%P", "a")
+#                 c = c.replace("%S", "ss")
+#                 c = c.replace("%O", "s")
+#                 c = c.replace("%Y", "yy")
+#                 c = c.replace("%W", "yyyy")
+#                 c = c.replace("%Z", "H:m:s")
+#                 c = c.replace("%A", "D")
+#                 c = c.replace("%Q", "a")    # AM/PM
+#                 c = c.replace("%K", "")    # undocumented... seen in cef.xml
+#                 c = c.replace("%L", "")    # undocumented... seen in cef.xml
+#                 c = c.replace("%E", "")    # undocumented... seen in v20_trendmicromsg.xml
+#                 c = c.replace("%X", "UNIX")
+#                 if '%' in c: print("Missing a condition in date conversion: " + c)
+#     return c
 
 # converting STRCAT
 def convertStrcat(s):
@@ -137,6 +163,10 @@ def escapeGrok(s):
 def escapeDissect(s):
     if s == "": return s
     return "\"" + str.strip(s.replace("\"","\\\"")) + "\""
+
+# escapes a string in logstash (only escaping ")
+def escapeString(s):
+    return str.strip(s.replace("\"","\\\""))
 
 # escape special characters in grok :  \ . ^ $ * + - ? ( ) [ ] { } |
 def escapeRegex(s):

--- a/input.conf
+++ b/input.conf
@@ -7,15 +7,15 @@ input {
 #	syslog {
 #		port => 514
 #	}
-	file {
-		path => "/var/log/example.log"
-		start_position => "beginning"
-		sincedb_path => "/dev/null"
-	}
-#	generator {
-#		count => 1
-#		message => "a log line to test out"
+#	file {
+#		path => "/var/log/example.log"
+#		start_position => "beginning"
+#		sincedb_path => "/dev/null"
 #	}
+	generator {
+		count => 1
+		message => "a log line to test out"
+	}
 #	kafka {
 #		codec => "json"
 #		bootstrap_servers => "192.168.30.13:9092"


### PR DESCRIPTION
bug fixes dans v2.2 :

- remonter des infos plus précises en cas de parsing error
- \ en fin de grok (et de log), cf message MasterControl_6 de v20_celerramsg.xml
- guillement dans id message =======EXCEPTION de v20_symantecavmsg.xml ou dans message PredictabletmpfilesWhenUsing"here"Documents de v20_enterceptmsg.xml
- vérifier l'échappement de dissect : pb double \\ dans message Security_Alert de  j4carehccmsg.xml
- pb d'échappement << (contenu ajouté dans la liste de fields) ! cf message Security_Alert de  j4carehccmsg.xml
- parfois 2 EVENTTIME: cf message CylancePROTECT:21 de cylancemsg.xml => ne prendre que le champ event_time
- EVNTTIME($MSG,'%G/%F/%W %N:%U:%O %Q',fld51), le %Q pas documenté dans message CylancePROTECT:21 de cylancemsg.xml
- pb aussi de %K et %L dans date de message netwitnessspectrum de cef.xml
- et %E dans date de  sunoneldapmsg.xml
- evnttime peut avoir plusieurs strings, cf EVT_SMTP_POP3_CONTENT_FILTERING dans v20_trendmicromsg.xml
